### PR TITLE
[테스트 데이터 생성기] CH 03. CLIP 08. 로직 구현: 개인 스키마 정보 읽어들이기

### DIFF
--- a/src/main/java/com/fastcampus10pjt/testdata/controller/TableSchemaController.java
+++ b/src/main/java/com/fastcampus10pjt/testdata/controller/TableSchemaController.java
@@ -7,11 +7,14 @@ import com.fastcampus10pjt.testdata.domain.dto.request.TableSchemaRequest;
 import com.fastcampus10pjt.testdata.domain.dto.response.SchemaFieldResponse;
 import com.fastcampus10pjt.testdata.domain.dto.response.SimpleTableSchemaResponse;
 import com.fastcampus10pjt.testdata.domain.dto.response.TableSchemaResponse;
+import com.fastcampus10pjt.testdata.domain.dto.security.GithubUser;
+import com.fastcampus10pjt.testdata.service.TableSchemaService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,7 +23,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
-import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
 
@@ -28,6 +30,7 @@ import java.util.List;
 @Controller
 public class TableSchemaController {
 
+    private final TableSchemaService tableSchemaService;
     private final ObjectMapper mapper;
 
     @GetMapping("/table-schema")
@@ -54,8 +57,14 @@ public class TableSchemaController {
     }
 
     @GetMapping("/table-schema/my-schemas")
-    public String mySchema(Model model) {
-        var tableSchemas = mySampleSchemas();
+    public String mySchema(
+            @AuthenticationPrincipal GithubUser githubUser,
+            Model model
+    ) {
+        List<SimpleTableSchemaResponse> tableSchemas = tableSchemaService.loadMySchemas(githubUser.id())
+                .stream()
+                .map(SimpleTableSchemaResponse::fromDto)
+                .toList();
 
         model.addAttribute("tableSchemas", tableSchemas);
 
@@ -87,14 +96,6 @@ public class TableSchemaController {
                         new SchemaFieldResponse("age", MockDataType.NUMBER, 3, 20, null, null),
                         new SchemaFieldResponse("my_car", MockDataType.CAR, 4, 50, null, null)
                 )
-        );
-    }
-
-    private static List<SimpleTableSchemaResponse> mySampleSchemas() {
-        return List.of(
-                new SimpleTableSchemaResponse("schema_name1", "Uno", LocalDate.of(2025, 1, 1).atStartOfDay()),
-                new SimpleTableSchemaResponse("schema_name2", "Uno", LocalDate.of(2025, 2, 2).atStartOfDay()),
-                new SimpleTableSchemaResponse("schema_name3", "Uno", LocalDate.of(2025, 3, 3).atStartOfDay())
         );
     }
 

--- a/src/main/java/com/fastcampus10pjt/testdata/controller/TableSchemaController.java
+++ b/src/main/java/com/fastcampus10pjt/testdata/controller/TableSchemaController.java
@@ -35,10 +35,13 @@ public class TableSchemaController {
 
     @GetMapping("/table-schema")
     public String tableSchema(
+            @AuthenticationPrincipal GithubUser githubUser,
             @RequestParam(required = false) String schemaName,
             Model model)
     {
-        var tableSchema = defaultTableSchema(schemaName);
+        TableSchemaResponse tableSchema = (githubUser != null && schemaName != null) ?
+                TableSchemaResponse.fromDto(tableSchemaService.loadMySchema(githubUser.id(), schemaName)) :
+                defaultTableSchema(schemaName);
 
         model.addAttribute("tableSchema", tableSchema);
         model.addAttribute("mockDataTypes", MockDataType.toObjects());

--- a/src/main/java/com/fastcampus10pjt/testdata/service/TableSchemaService.java
+++ b/src/main/java/com/fastcampus10pjt/testdata/service/TableSchemaService.java
@@ -1,0 +1,32 @@
+package com.fastcampus10pjt.testdata.service;
+
+import com.fastcampus10pjt.testdata.domain.dto.TableSchemaDto;
+import com.fastcampus10pjt.testdata.repository.TableSchemaRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class TableSchemaService {
+
+    private final TableSchemaRepository tableSchemaRepository;
+
+    @Transactional(readOnly = true)
+    public List<TableSchemaDto> loadMySchemas(String userId) {
+        return loadMySchemas(userId, Pageable.unpaged()).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public Page<TableSchemaDto> loadMySchemas(String userId, Pageable pageable) {
+        return tableSchemaRepository.findByUserId(userId, pageable)
+                .map(TableSchemaDto::fromEntity);
+    }
+
+}

--- a/src/main/java/com/fastcampus10pjt/testdata/service/TableSchemaService.java
+++ b/src/main/java/com/fastcampus10pjt/testdata/service/TableSchemaService.java
@@ -29,4 +29,11 @@ public class TableSchemaService {
                 .map(TableSchemaDto::fromEntity);
     }
 
+    @Transactional(readOnly = true)
+    public TableSchemaDto loadMySchema(String userId, String schemaName) {
+        return tableSchemaRepository.findByUserIdAndSchemaName(userId, schemaName)
+                .map(TableSchemaDto::fromEntity)
+                .orElseThrow(() -> new EntityNotFoundException("테이블 스키마가 없습니다 - userId: " + userId + ", schemaName: " + schemaName));
+    }
+
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,7 +1,7 @@
 -- 예제 테이블 스키마
 insert into table_schema (id, schema_name, user_id, exported_at, created_at, created_by, modified_at, modified_by)
 values
-    (1, 'test_schema1', 'djkeh', null, now(), 'uno', now(), 'uno')
+    (1, 'test_schema1', 'shinnhyuk', null, now(), 'kshinn', now(), 'kshinn')
 ;
 
 -- 테이블 스키마 id를 직접 입력하였으므로 auto increment 수치를 직접 제어해줘야 함
@@ -12,10 +12,10 @@ insert into schema_field (table_schema_id, field_order, field_name, mock_data_ty
                           type_option_json, blank_percent, force_value,
                           created_at, created_by, modified_at, modified_by)
 values
-    (1, 1, 'id', 'ROW_NUMBER', '{"start": 1, "step": 1}', 0, null, now(), 'uno', now(), 'uno'),
-    (1, 3, 'age', 'NUMBER', '{"min": 10, "max": 30, "decimals": 0}', 50, null, now(), 'uno', now(), 'uno'),
-    (1, 2, 'name', 'STRING', '{"minLength": 1, "maxLength": 10}', 0, null, now(), 'uno', now(), 'uno'),
-    (1, 4, 'active', 'BOOLEAN', null, 0, 'true', now(), 'uno', now(), 'uno')
+    (1, 1, 'id', 'ROW_NUMBER', '{"start": 1, "step": 1}', 0, null, now(), 'kshinn', now(), 'kshinn'),
+    (1, 3, 'age', 'NUMBER', '{"min": 10, "max": 30, "decimals": 0}', 50, null, now(), 'kshinn', now(), 'kshinn'),
+    (1, 2, 'name', 'STRING', '{"minLength": 1, "maxLength": 10}', 0, null, now(), 'kshinn', now(), 'kshinn'),
+    (1, 4, 'active', 'BOOLEAN', null, 0, 'true', now(), 'kshinn', now(), 'kshinn')
 ;
 
 -- 샘플 가짜 데이터

--- a/src/test/java/com/fastcampus10pjt/testdata/controller/TableSchemaControllerTest.java
+++ b/src/test/java/com/fastcampus10pjt/testdata/controller/TableSchemaControllerTest.java
@@ -60,7 +60,7 @@ class TableSchemaControllerTest {
                 .andExpect(model().attributeExists("mockDataTypes"))
                 .andExpect(model().attributeExists("fileTypes"))
                 .andExpect(view().name("table-schema"));
-
+        then(tableSchemaService).shouldHaveNoInteractions(); // 서비스 호출 없음
     }
 
     @DisplayName("[GET] 테이블 스키마 조회, 로그인 + 특정 테이블 스키마 (정상)")
@@ -69,6 +69,13 @@ class TableSchemaControllerTest {
         // Given
         var githubUser = new GithubUser("test-id", "test-name", "test@email.com");
         var schemaName = "test_schema";
+        given(tableSchemaService.loadMySchema(githubUser.id(), schemaName))
+                .willReturn(TableSchemaDto.of(
+                        schemaName,
+                        githubUser.id(),
+                        null,
+                        Set.of()
+                ));
 
         // When & Then
         mvc.perform(
@@ -84,7 +91,7 @@ class TableSchemaControllerTest {
                 .andExpect(model().attributeExists("fileTypes"))
                 .andExpect(content().string(containsString(schemaName))) // html 전체 검사로
                 .andExpect(view().name("table-schema"));
-
+        then(tableSchemaService).should().loadMySchema(githubUser.id(), schemaName);
     }
 
     @DisplayName("[POST] 테이블 스키마 생성, 변경 (정상)")

--- a/src/test/java/com/fastcampus10pjt/testdata/controller/TableSchemaControllerTest.java
+++ b/src/test/java/com/fastcampus10pjt/testdata/controller/TableSchemaControllerTest.java
@@ -3,24 +3,32 @@ package com.fastcampus10pjt.testdata.controller;
 import com.fastcampus10pjt.testdata.config.SecurityConfig;
 import com.fastcampus10pjt.testdata.domain.constant.ExportFileType;
 import com.fastcampus10pjt.testdata.domain.constant.MockDataType;
+import com.fastcampus10pjt.testdata.domain.dto.TableSchemaDto;
 import com.fastcampus10pjt.testdata.domain.dto.request.SchemaFieldRequest;
 import com.fastcampus10pjt.testdata.domain.dto.request.TableSchemaExportRequest;
 import com.fastcampus10pjt.testdata.domain.dto.request.TableSchemaRequest;
+import com.fastcampus10pjt.testdata.domain.dto.response.SimpleTableSchemaResponse;
 import com.fastcampus10pjt.testdata.domain.dto.security.GithubUser;
+import com.fastcampus10pjt.testdata.service.TableSchemaService;
 import com.fastcampus10pjt.testdata.util.FormDataEncoder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.mockito.BDDMockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -31,11 +39,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @DisplayName("[Controller] 테이블 스키마 컨트롤러 테스트")
 @Import({SecurityConfig.class, FormDataEncoder.class})
 @WebMvcTest(TableSchemaController.class)
-record TableSchemaControllerTest(
-        @Autowired MockMvc mvc,
-        @Autowired FormDataEncoder formDataEncoder,
-        @Autowired ObjectMapper mapper
-) {
+class TableSchemaControllerTest {
+
+    @Autowired private MockMvc mvc;
+    @Autowired private FormDataEncoder formDataEncoder;
+    @Autowired private ObjectMapper mapper;
+
+    @MockitoBean private TableSchemaService tableSchemaService;
 
     @DisplayName("[GET] 테이블 스키마 조회, 비로그인 최초 진입 (정상)")
     @Test
@@ -114,6 +124,7 @@ record TableSchemaControllerTest(
         mvc.perform(get("/table-schema/my-schemas"))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrlPattern("**/oauth2/authorization/github")); // Ant style pattern
+        then(tableSchemaService).shouldHaveNoInteractions(); // 서비스 호출 없음
     }
 
     @DisplayName("[GET] 내 스키마 목록 조회 (정상)")
@@ -121,6 +132,8 @@ record TableSchemaControllerTest(
     void givenAuthenticatedUser_whenRequestingMySchemas_thenShowsMySchemasView() throws Exception {
         // Given
         var githubUser = new GithubUser("test-id", "test-name", "test@email.com");
+        given(tableSchemaService.loadMySchemas(githubUser.id()))
+                .willReturn(List.of());
 
         // When & Then
         mvc.perform(
@@ -129,8 +142,9 @@ record TableSchemaControllerTest(
                 )
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
-                .andExpect(model().attributeExists("tableSchemas"))
+                .andExpect(model().attribute("tableSchemas", List.of()))
                 .andExpect(view().name("my-schemas"));
+        then(tableSchemaService).should().loadMySchemas(githubUser.id());
     }
 
     @DisplayName("[POST] 내 스키마 삭제 (정상)")

--- a/src/test/java/com/fastcampus10pjt/testdata/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/fastcampus10pjt/testdata/repository/JpaRepositoryTest.java
@@ -35,7 +35,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 @DataJpaTest
 class JpaRepositoryTest {
 
-    private static final String TEST_AUDITOR = "test_uno";
+    private static final String TEST_AUDITOR = "test_kshinn";
 
     @Autowired
     private MockDataRepository mockDataRepository;
@@ -66,7 +66,7 @@ class JpaRepositoryTest {
         assertThat(tableSchemas).hasSize(1)
                 .first()
                 .hasFieldOrPropertyWithValue("schemaName", "test_schema1")
-                .hasFieldOrPropertyWithValue("userId", "djkeh")
+                .hasFieldOrPropertyWithValue("userId", "shinnhyuk")
                 .extracting("schemaFields", InstanceOfAssertFactories.COLLECTION)
                 .hasSize(4);
     }
@@ -74,7 +74,7 @@ class JpaRepositoryTest {
     @Test
     void insertTest() {
         // Given
-        TableSchema tableSchema = TableSchema.of("test_schema", "uno");
+        TableSchema tableSchema = TableSchema.of("test_schema", "shinnhyuk");
         tableSchema.addSchemaFields(List.of(
                 SchemaField.of("id", MockDataType.ROW_NUMBER, 1, 0, null, null),
                 SchemaField.of("age", MockDataType.NUMBER, 2, 10, null, null),
@@ -89,7 +89,7 @@ class JpaRepositoryTest {
         TableSchema newTableSchema = tableSchemaRepository.findById(saved.getId()).orElseThrow();
         assertThat(newTableSchema)
                 .hasFieldOrPropertyWithValue("schemaName", "test_schema")
-                .hasFieldOrPropertyWithValue("userId", "uno")
+                .hasFieldOrPropertyWithValue("userId", "shinnhyuk")
                 .hasFieldOrPropertyWithValue("createdBy", TEST_AUDITOR)
                 .hasFieldOrPropertyWithValue("modifiedBy", TEST_AUDITOR)
                 .hasFieldOrProperty("createdAt")
@@ -117,7 +117,7 @@ class JpaRepositoryTest {
         // Then
         assertThat(updated)
                 .hasFieldOrPropertyWithValue("schemaName", "test_modified")
-                .hasFieldOrPropertyWithValue("createdBy", "uno")
+                .hasFieldOrPropertyWithValue("createdBy", "kshinn")
                 .hasFieldOrPropertyWithValue("modifiedBy", TEST_AUDITOR)
                 .extracting("schemaFields", InstanceOfAssertFactories.COLLECTION)
                 .hasSize(1);

--- a/src/test/java/com/fastcampus10pjt/testdata/repository/TableSchemaRepositoryTest.java
+++ b/src/test/java/com/fastcampus10pjt/testdata/repository/TableSchemaRepositoryTest.java
@@ -26,7 +26,7 @@ class TableSchemaRepositoryTest {
     @Test
     void givenUserIdAndPagingInfo_whenSelecting_thenReturnPagedTableSchema(){
         // Given
-        var userId = "djkeh";
+        var userId = "shinnhyuk";
         var pageable = Pageable.ofSize(5);
 
         // When
@@ -46,7 +46,7 @@ class TableSchemaRepositoryTest {
     @Test
     void givenUserIdAndSchemaName_whenSelecting_thenReturnsTableSchema(){
         // Given
-        var userId = "djkeh";
+        var userId = "shinnhyuk";
         var schemaName = "test_schema1";
 
         // When
@@ -63,7 +63,7 @@ class TableSchemaRepositoryTest {
     @Test
     void givenUserIdAndSchemaName_whenDeletingTableSchema_thenDeletes(){
         // Given
-        var userId = "djkeh";
+        var userId = "shinnhyuk";
         var schemaName = "test_schema1";
 
         // When

--- a/src/test/java/com/fastcampus10pjt/testdata/service/TableSchemaServiceTest.java
+++ b/src/test/java/com/fastcampus10pjt/testdata/service/TableSchemaServiceTest.java
@@ -1,0 +1,57 @@
+package com.fastcampus10pjt.testdata.service;
+
+import com.fastcampus10pjt.testdata.domain.TableSchema;
+import com.fastcampus10pjt.testdata.domain.dto.TableSchemaDto;
+import com.fastcampus10pjt.testdata.repository.TableSchemaRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@DisplayName("[Service] 테이블 스키마 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+class TableSchemaServiceTest {
+
+    @InjectMocks
+    private TableSchemaService sut;
+
+    @Mock
+    private TableSchemaRepository tableSchemaRepository;
+
+    @DisplayName("사용자 ID가 주어지면, 테이블 스키마 목록을 반환한다.")
+    @Test
+    void givenUserId_whenLoadingMySchemas_thenReturnsTableSchemaList() {
+        // Given
+        String userId = "userId";
+        given(tableSchemaRepository.findByUserId(userId, Pageable.unpaged()))
+                .willReturn(new PageImpl<>(List.of(
+                        TableSchema.of("table1", userId),
+                        TableSchema.of("table2", userId),
+                        TableSchema.of("table3", userId)
+                )));
+
+        // When
+        List<TableSchemaDto> result = sut.loadMySchemas(userId);
+
+        // Then
+        assertThat(result)
+                .hasSize(3)
+                .extracting("schemaName")
+                .containsExactly("table1", "table2", "table3");
+        then(tableSchemaRepository).should().findByUserId(userId, Pageable.unpaged());
+    }
+
+}

--- a/src/test/java/com/fastcampus10pjt/testdata/service/TableSchemaServiceTest.java
+++ b/src/test/java/com/fastcampus10pjt/testdata/service/TableSchemaServiceTest.java
@@ -54,4 +54,43 @@ class TableSchemaServiceTest {
         then(tableSchemaRepository).should().findByUserId(userId, Pageable.unpaged());
     }
 
+    @DisplayName("사용자 ID와 스키마 이름이 주어지면, 테이블 스키마를 반환한다.")
+    @Test
+    void givenUserIdAndSchemaName_whenLoadingMySchema_thenReturnsTableSchema() {
+        // Given
+        String userId = "userId";
+        String schemaName = "table1";
+        TableSchema tableSchema = TableSchema.of(schemaName, userId);
+        given(tableSchemaRepository.findByUserIdAndSchemaName(userId, schemaName))
+                .willReturn(Optional.of(tableSchema));
+
+        // When
+        TableSchemaDto result = sut.loadMySchema(userId, schemaName);
+
+        // Then
+        assertThat(result)
+                .hasFieldOrPropertyWithValue("schemaName", schemaName)
+                .hasFieldOrPropertyWithValue("userId", userId);
+        then(tableSchemaRepository).should().findByUserIdAndSchemaName(userId, schemaName);
+    }
+
+    @DisplayName("사용자 ID와 스키마 이름에 대응하는 테이블 스키마가 없을 경우, 예외를 던진다.")
+    @Test
+    void givenUserIdAndSchemaName_whenLoadingNoneExistingMySchema_thenThrowsException() {
+        // Given
+        String userId = "userId";
+        String schemaName = "table1";
+        given(tableSchemaRepository.findByUserIdAndSchemaName(userId, schemaName))
+                .willReturn(Optional.empty());
+
+        // When
+        Throwable t = catchThrowable( () -> sut.loadMySchema(userId, schemaName));
+
+        // Then
+        assertThat(t)
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("테이블 스키마가 없습니다 - userId: " + userId + ", schemaName: " + schemaName);
+        then(tableSchemaRepository).should().findByUserIdAndSchemaName(userId, schemaName);
+    }
+
 }


### PR DESCRIPTION
이 pr은 내 스키마 목록을 읽어들이는 비즈니스 로직을 구현.
또한, 회원 스키마 테이블 단건 조회 구현.

컨트롤러 api에 상기 로직 연결 지음.

This closes #42 