### PR TITLE
[테스트 데이터 생성기] CH 03. CLIP 09. 로직 구현: 개인 스키마 정보 저장하기

### DIFF
--- a/src/main/java/com/fastcampus10pjt/testdata/controller/TableSchemaController.java
+++ b/src/main/java/com/fastcampus10pjt/testdata/controller/TableSchemaController.java
@@ -52,10 +52,14 @@ public class TableSchemaController {
 
     @PostMapping("/table-schema")
     public String createOrUpdateTableSchema(
+            @AuthenticationPrincipal GithubUser githubUser,
             TableSchemaRequest tableSchemaRequest,
             RedirectAttributes redirectAttrs
     ) {
+        tableSchemaService.saveMySchema(tableSchemaRequest.toDto(githubUser.id()));
+
         redirectAttrs.addFlashAttribute("tableSchemaRequest", tableSchemaRequest);
+
         return "redirect:/table-schema";
     }
 

--- a/src/main/java/com/fastcampus10pjt/testdata/domain/dto/request/TableSchemaRequest.java
+++ b/src/main/java/com/fastcampus10pjt/testdata/domain/dto/request/TableSchemaRequest.java
@@ -7,17 +7,17 @@ import java.util.stream.Collectors;
 
 public record TableSchemaRequest(
         String schemaName,
-        String userId,
         List<SchemaFieldRequest> schemaFields
 ) {
-    public static TableSchemaRequest of(String schemaName, String userId, List<SchemaFieldRequest> schemaFields) {
-        return new TableSchemaRequest(schemaName, userId, schemaFields);
+
+    public static TableSchemaRequest of(String schemaName, List<SchemaFieldRequest> schemaFields) {
+        return new TableSchemaRequest(schemaName, schemaFields);
     }
 
-    public TableSchemaDto toDto() {
+    public TableSchemaDto toDto(String userId) {
         return TableSchemaDto.of(
-                schemaName(),
-                userId(),
+                schemaName,
+                userId,
                 null, // exportedAt is not provided in the request
                 schemaFields.stream()
                         .map(SchemaFieldRequest::toDto)

--- a/src/main/java/com/fastcampus10pjt/testdata/service/TableSchemaService.java
+++ b/src/main/java/com/fastcampus10pjt/testdata/service/TableSchemaService.java
@@ -36,4 +36,8 @@ public class TableSchemaService {
                 .orElseThrow(() -> new EntityNotFoundException("테이블 스키마가 없습니다 - userId: " + userId + ", schemaName: " + schemaName));
     }
 
+    public void saveMySchema(TableSchemaDto dto) {
+        tableSchemaRepository.save(dto.createEntity());
+    }
+
 }

--- a/src/test/java/com/fastcampus10pjt/testdata/controller/TableSchemaControllerTest.java
+++ b/src/test/java/com/fastcampus10pjt/testdata/controller/TableSchemaControllerTest.java
@@ -7,17 +7,14 @@ import com.fastcampus10pjt.testdata.domain.dto.TableSchemaDto;
 import com.fastcampus10pjt.testdata.domain.dto.request.SchemaFieldRequest;
 import com.fastcampus10pjt.testdata.domain.dto.request.TableSchemaExportRequest;
 import com.fastcampus10pjt.testdata.domain.dto.request.TableSchemaRequest;
-import com.fastcampus10pjt.testdata.domain.dto.response.SimpleTableSchemaResponse;
 import com.fastcampus10pjt.testdata.domain.dto.security.GithubUser;
 import com.fastcampus10pjt.testdata.service.TableSchemaService;
 import com.fastcampus10pjt.testdata.util.FormDataEncoder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.BDDMockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -101,13 +98,13 @@ class TableSchemaControllerTest {
         var githubUser = new GithubUser("test-id", "test-name", "test@email.com");
         TableSchemaRequest request = TableSchemaRequest.of(
                 "test_schema",
-                "홍길동",
                 List.of(
                         SchemaFieldRequest.of("id", MockDataType.ROW_NUMBER, 1, 0, null, null),
                         SchemaFieldRequest.of("name", MockDataType.NAME, 2, 10, null, null),
                         SchemaFieldRequest.of("age", MockDataType.NUMBER, 3, 20, null, null)
                 )
         );
+        willDoNothing().given(tableSchemaService).saveMySchema(request.toDto(githubUser.id()));
 
         // When & Then
         mvc.perform(
@@ -120,6 +117,7 @@ class TableSchemaControllerTest {
                 .andExpect(status().is3xxRedirection())
                 .andExpect(flash().attribute("tableSchemaRequest", request))
                 .andExpect(redirectedUrl("/table-schema"));
+        then(tableSchemaService).should().saveMySchema(request.toDto(githubUser.id()));
     }
 
     @DisplayName("[GET] 내 스키마 목록 조회 (비로그인)")

--- a/src/test/java/com/fastcampus10pjt/testdata/service/TableSchemaServiceTest.java
+++ b/src/test/java/com/fastcampus10pjt/testdata/service/TableSchemaServiceTest.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
@@ -91,6 +92,20 @@ class TableSchemaServiceTest {
                 .isInstanceOf(EntityNotFoundException.class)
                 .hasMessage("테이블 스키마가 없습니다 - userId: " + userId + ", schemaName: " + schemaName);
         then(tableSchemaRepository).should().findByUserIdAndSchemaName(userId, schemaName);
+    }
+
+    @DisplayName("테이블 스키마 정보가 주어지면, 테이블 스키마를 저장한다.")
+    @Test
+    void givenTableSchema_whenInserting_thenCreateTableSchema(){
+        // Given
+        TableSchemaDto dto = TableSchemaDto.of("table1", "userId", null, Set.of());
+        given(tableSchemaRepository.save(dto.createEntity())).willReturn(null);
+
+        // When
+        sut.saveMySchema(dto);
+
+        // Then
+        then(tableSchemaRepository).should().save(dto.createEntity());
     }
 
 }


### PR DESCRIPTION
이 작업은 회원의 스키마 테이블 저장 기능을 구현한다.

This closes #48 